### PR TITLE
Improve reusable workflow to use project secrets and variables instead

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -9,7 +9,7 @@ on:
         required: true
         default: patch
     secrets:
-      ACTIONS_PAT:
+      STARTER_KIT_ACTIONS_TOKEN:
         description: A personal access token (PAT) for used in GitHub Actions
         required: true
 
@@ -28,12 +28,12 @@ jobs:
         with:
           type: ${{ inputs.release-type }} 
           prerelease: true
-          tag-prefix: release/
+          tag-prefix: ${{ vars.STARTER_KIT_TAG_PREFIX }}
       # push git tag and create GitHub prerelease
       - uses: kimichiro/starter-kit-github-actions/.github/actions/create-github-release@HEAD
         id: create-prerelease-release
         with:
-          tag-name: release/${{ steps.bump-prerelease-version.outputs.version }}
+          tag-name: ${{ vars.STARTER_KIT_TAG_PREFIX }}${{ steps.bump-prerelease-version.outputs.version }}
           prerelease: true
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}
+          GITHUB_TOKEN: ${{ secrets.STARTER_KIT_ACTIONS_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ on:
         required: true
         default: patch
     secrets:
-      ACTIONS_PAT:
+      STARTER_KIT_ACTIONS_TOKEN:
         description: A personal access token (PAT) for used in GitHub Actions
         required: true
 
@@ -27,11 +27,11 @@ jobs:
         id: bump-release-version
         with:
           type: ${{ inputs.release-type }} 
-          tag-prefix: release/
+          tag-prefix: ${{ vars.STARTER_KIT_TAG_PREFIX }}
       # push git tag and create GitHub release
       - uses: kimichiro/starter-kit-github-actions/.github/actions/create-github-release@HEAD
         id: create-release-release
         with:
-          tag-name: release/${{ steps.bump-release-version.outputs.version }}
+          tag-name: ${{ vars.STARTER_KIT_TAG_PREFIX }}${{ steps.bump-release-version.outputs.version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_PAT }}
+          GITHUB_TOKEN: ${{ secrets.STARTER_KIT_ACTIONS_TOKEN }}

--- a/.github/workflows/sample-publish-prerelease.yml
+++ b/.github/workflows/sample-publish-prerelease.yml
@@ -15,25 +15,9 @@ on:
 
 jobs:
   publish-release:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
-      # bump semantic version as prerelease
-      - uses: ./.github/actions/bump-semantic-version
-        id: bump-prerelease-version
-        with:
-          type: ${{ inputs.release-type }} 
-          prerelease: true
-          tag-prefix: release/
-      # push git tag and create GitHub prerelease
-      - uses: ./.github/actions/create-github-release
-        id: create-prerelease-release
-        with:
-          tag-name: release/${{ steps.bump-prerelease-version.outputs.version }}
-          prerelease: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/publish-prerelease.yml
+    with:
+      release-type: ${{ inputs.release-type }}
+    secrets: inherit

--- a/.github/workflows/sample-publish-release.yml
+++ b/.github/workflows/sample-publish-release.yml
@@ -15,23 +15,9 @@ on:
 
 jobs:
   publish-release:
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-tags: true
-      # bump semantic version as release
-      - uses: ./.github/actions/bump-semantic-version
-        id: bump-release-version
-        with:
-          type: ${{ inputs.release-type }} 
-          tag-prefix: release/
-      # push git tag and create GitHub release
-      - uses: ./.github/actions/create-github-release
-        id: create-release-release
-        with:
-          tag-name: release/${{ steps.bump-release-version.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      release-type: ${{ inputs.release-type }}
+    secrets: inherit


### PR DESCRIPTION
**_Changes log:_**

- Following changes apply to both `Publish Prerelease` and `Publish Release`
- Rename secret `ACTIONS_PAT` to `STARTER_KIT_ACTIONS_TOKEN` #15 
- Using variable `STARTER_KIT_TAG_PREFIX` instead of constant value #15 