### PR TITLE
Add reusable actions for build, test and publish npm package

### DIFF
--- a/.github/actions/build-test-npm/LICENSE
+++ b/.github/actions/build-test-npm/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/.github/actions/build-test-npm/README.md
+++ b/.github/actions/build-test-npm/README.md
@@ -1,0 +1,27 @@
+# Build and Test (Npm)
+
+Run build and test on npm package.
+- Update package version with given `version` input.
+- Clean install dependency packages without modifying `package-lock.json`.
+- Build and test package, prerequisites must be provided by package owner.
+- Pack package content into a zip file only if `pack` input is set to `true`.
+
+## Usage
+
+```yml
+- uses: actions/checkout@v4
+- uses: actions/setup-node@v4
+- uses: ./.github/actions/build-test-npm
+  with:
+    version: 1.0.0
+    pack: true
+```
+
+## Inputs
+
+- `version` - Semantic version to be set as npm package version, skip if unset.
+- `pack` - Whether to pack a package in zip file. _Default_: `false`
+
+## Outputs
+
+- `package-name` - Package file name.

--- a/.github/actions/build-test-npm/action.yml
+++ b/.github/actions/build-test-npm/action.yml
@@ -1,0 +1,35 @@
+name: Build and Test (Npm)
+description: Run build and test on npm package
+inputs:
+  version:
+    description: Semantic version to be set as npm package version, skip if unset
+  pack:
+    description: Whether to pack a package in zip file
+    default: 'false'
+outputs:
+  package-name:
+    description: Package file name
+    value: ${{ steps.generator.outputs.package-name }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set Package Version
+      run: |
+        [[ "${{ inputs.version }}" ]] && npm pkg set version="${{ inputs.version }}"
+      shell: bash
+    - name: Clean Install
+      run: npm ci
+      shell: bash
+    - name: Build Package
+      run: npm run build
+      shell: bash
+    - name: Test Package
+      run: npm test
+      shell: bash
+    - name: Pack Contents
+      run: |
+        [[ "${{ inputs.pack }}" == [Tt][Rr][Uu][Ee] ]] && PACKAGE_NAME=$(npm pack)
+        echo "package-name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+      shell: bash
+

--- a/.github/actions/publish-npm/LICENSE
+++ b/.github/actions/publish-npm/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/.github/actions/publish-npm/README.md
+++ b/.github/actions/publish-npm/README.md
@@ -1,0 +1,25 @@
+# Publish Npm Package
+
+Publish npm package.
+- Setup registry with authentication token.
+- Publish package to registry.
+
+## Usage
+
+```yml
+- uses: actions/checkout@v4
+- uses: actions/setup-node@v4
+- uses: ./.github/actions/publish-npm
+  with:
+    registry-url: https://npm.pkg.github.com/
+    scope: hello-world
+```
+
+## Inputs
+
+- `registry-url` - _**required** _Npm package registry to publish a package to.
+- `scope` - Package scope associated with registry-url.
+
+## Environments
+
+- `NODE_AUTH_TOKEN` - authentication token to npm registry (e.g. secrets.GITHUB_TOKEN or GitHub personal access token with permission packages: write)

--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -1,0 +1,28 @@
+name: Publish Npm Package
+description: Publish npm package
+inputs:
+  registry-url:
+    description: npm package registry to publish a package to
+    required: true
+  scope:
+    description: package scope associated with `registry-url`
+
+runs:
+  using: composite
+  steps:
+    - name: Validate Inputs
+      run: |
+        [[ "${{ inputs.registry-url }}" ]] || { echo "'registry-url' must not be empty string" ; exit 1 ; }
+      shell: bash
+    - name: Setup Npm Registry
+      run: |
+        if [[ "${{ inputs.scope }}" ]]; \
+          then npm config set @${{ inputs.scope }}:registry="${{ inputs.registry-url }}" --location project; \
+          else npm config set registry="${{ inputs.registry-url }}" --location project; \
+        fi
+        REGISTRY_URL=${{ inputs.registry-url }}
+        npm config set //${REGISTRY_URL/#http*:\/\//}:_authToken=$NODE_AUTH_TOKEN --location project
+      shell: bash
+    - name: Publish Package
+      run: npm publish
+      shell: bash


### PR DESCRIPTION
**_Changes log:_**

- Add action build-test-npm which also supports CI run without packing content or publish #11 
- Add action publish-npm with customizable input for scope and registry url #12 